### PR TITLE
Remove redundant page padding

### DIFF
--- a/S3WebClient/src/pages/Buckets.tsx
+++ b/S3WebClient/src/pages/Buckets.tsx
@@ -171,7 +171,7 @@ const Buckets: React.FC = () => {
         alignItems: "flex-start",
       }}
     >
-      <Box sx={{ width: "100%", p: 2 }}>
+      <Box sx={{ width: "100%" }}>
         {/* Header Section */}
         <Box sx={{ mb: 3 }}>
           <Typography

--- a/S3WebClient/src/pages/Dashboard.tsx
+++ b/S3WebClient/src/pages/Dashboard.tsx
@@ -89,7 +89,7 @@ export default function Dashboard() {
         alignItems: "flex-start",
       }}
     >
-      <Box sx={{ width: "100%", p: 2 }}>
+      <Box sx={{ width: "100%" }}>
         {/* Welcome Header */}
         <Box sx={{ mb: 3 }}>
           <Typography

--- a/S3WebClient/src/pages/Profile.tsx
+++ b/S3WebClient/src/pages/Profile.tsx
@@ -102,7 +102,7 @@ export default function Profile() {
         alignItems: "flex-start",
       }}
     >
-      <Box sx={{ width: "100%", p: 2 }}>
+      <Box sx={{ width: "100%" }}>
         {/* Profile Header */}
         <Box sx={{ mb: 3 }}>
           <Typography

--- a/S3WebClient/src/pages/Settings.tsx
+++ b/S3WebClient/src/pages/Settings.tsx
@@ -161,7 +161,7 @@ export default function Settings() {
         alignItems: "flex-start",
       }}
     >
-      <Box sx={{ width: "100%", p: 2 }}>
+      <Box sx={{ width: "100%" }}>
         {/* Header */}
         <Box sx={{ mb: 3 }}>
           <Typography


### PR DESCRIPTION
## Summary
- Eliminate extra padding from page containers so layout uses parent spacing only.

## Testing
- `npm run lint` *(fails: unused variables in pages)*
- `npm run build` *(fails: TypeScript unused declarations and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a65c0bfbd48320a698503bee8c2c8e