### PR TITLE
Add bucket detail page

### DIFF
--- a/S3WebClient/src/App.tsx
+++ b/S3WebClient/src/App.tsx
@@ -5,6 +5,7 @@ import Dashboard from "./pages/Dashboard";
 import Buckets from "./pages/Buckets";
 import Settings from "./pages/Settings";
 import Profile from "./pages/Profile";
+import Bucket from "./pages/Bucket";
 import "./App.css";
 
 function App() {
@@ -13,6 +14,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/buckets" element={<Buckets />} />
+        <Route path="/bucket/:id" element={<Bucket />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/profile" element={<Profile />} />
       </Routes>

--- a/S3WebClient/src/pages/Bucket.tsx
+++ b/S3WebClient/src/pages/Bucket.tsx
@@ -1,0 +1,132 @@
+import { useParams } from "react-router-dom";
+import { useS3Connections } from "../hooks/useS3Connections";
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+} from "@mui/material";
+import { Storage as StorageIcon } from "@mui/icons-material";
+
+export default function Bucket() {
+  const { id } = useParams();
+  const { connections, loading } = useS3Connections();
+  const connection = connections.find((c) => c.id === id);
+
+  if (loading) {
+    return (
+      <Box sx={{ width: "100%", minWidth: "100%" }}>
+        <Typography>Caricamento...</Typography>
+      </Box>
+    );
+  }
+
+  if (!connection) {
+    return (
+      <Box sx={{ width: "100%", minWidth: "100%" }}>
+        <Typography>Bucket non trovato</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        minWidth: "100%",
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        textAlign: "left",
+        alignItems: "flex-start",
+      }}
+    >
+      <Box sx={{ width: "100%" }}>
+        {/* Header */}
+        <Box sx={{ mb: 3 }}>
+          <Typography
+            variant="h5"
+            component="h1"
+            sx={{
+              mb: 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 2,
+              background: "linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)",
+              backgroundClip: "text",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              fontWeight: "bold",
+            }}
+          >
+            <StorageIcon sx={{ fontSize: 32, color: "primary.main" }} />
+            {connection.displayName}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+            Dettagli del bucket e contenuti
+          </Typography>
+        </Box>
+
+        {/* Bucket Info */}
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            <Typography
+              variant="h6"
+              sx={{ mb: 2, color: "primary.main", fontWeight: "bold" }}
+            >
+              Informazioni principali
+            </Typography>
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+                gap: 2,
+              }}
+            >
+              <Box>
+                <Typography variant="body2" color="text.secondary">
+                  Endpoint
+                </Typography>
+                <Typography variant="body1">{connection.endpoint}</Typography>
+              </Box>
+              <Box>
+                <Typography variant="body2" color="text.secondary">
+                  Bucket
+                </Typography>
+                <Typography variant="body1">{connection.bucketName}</Typography>
+              </Box>
+              {connection.region && (
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Regione
+                  </Typography>
+                  <Typography variant="body1">{connection.region}</Typography>
+                </Box>
+              )}
+              <Box>
+                <Typography variant="body2" color="text.secondary">
+                  Environment
+                </Typography>
+                <Typography variant="body1">
+                  {connection.environment.toUpperCase()}
+                </Typography>
+              </Box>
+            </Box>
+          </CardContent>
+        </Card>
+
+        {/* Placeholder for file navigation */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ mb: 1 }}>
+              Contenuti del bucket
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              La navigazione dei file e delle cartelle sarà disponibile prossimamente.
+            </Typography>
+          </CardContent>
+        </Card>
+      </Box>
+    </Box>
+  );
+}

--- a/S3WebClient/src/pages/Buckets.tsx
+++ b/S3WebClient/src/pages/Buckets.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   TextField,
   Button,
@@ -29,6 +30,7 @@ import {
   CheckCircle,
   Error,
   Info,
+  FolderOpen,
 } from "@mui/icons-material";
 import { useS3Connections } from "../hooks/useS3Connections";
 import ConnectionForm from "../components/ConnectionForm";
@@ -51,6 +53,8 @@ const Buckets: React.FC = () => {
     searchConnections,
     clearError,
   } = useS3Connections();
+
+  const navigate = useNavigate();
 
   const [searchTerm, setSearchTerm] = useState("");
   const [filteredConnections, setFilteredConnections] = useState<
@@ -455,6 +459,19 @@ const Buckets: React.FC = () => {
 
                   {/* Action Buttons */}
                   <CardActions sx={{ p: 1.5, pt: 0, gap: 0.5 }}>
+                    <Tooltip title="Apri">
+                      <IconButton
+                        size="small"
+                        onClick={() => navigate(`/bucket/${connection.id}`)}
+                        sx={{
+                          color: "secondary.main",
+                          "&:hover": { bgcolor: "secondary.50" },
+                        }}
+                      >
+                        <FolderOpen />
+                      </IconButton>
+                    </Tooltip>
+
                     <Tooltip title="Testa Connessione">
                       <IconButton
                         size="small"


### PR DESCRIPTION
## Summary
- add detailed bucket page and routing
- open buckets via new action button

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7643a68648320831856ab5a041af0