### PR TITLE
feat: add basic file management

### DIFF
--- a/S3WebClient/src/components/ObjectFlatList.tsx
+++ b/S3WebClient/src/components/ObjectFlatList.tsx
@@ -4,15 +4,30 @@ import ObjectItemRow from "./ObjectItemRow";
 
 interface Props {
   items: S3ObjectEntity[];
+  onDownload: (item: S3ObjectEntity) => void;
+  onRename: (item: S3ObjectEntity) => void;
+  onProperties: (item: S3ObjectEntity) => void;
 }
 
-export default function ObjectFlatList({ items }: Props) {
+export default function ObjectFlatList({
+  items,
+  onDownload,
+  onRename,
+  onProperties,
+}: Props) {
   return (
     <List disablePadding>
       {items
         .sort((a, b) => a.key.localeCompare(b.key))
         .map((item) => (
-          <ObjectItemRow key={item.key} item={item} name={item.key} />
+          <ObjectItemRow
+            key={item.key}
+            item={item}
+            name={item.key}
+            onDownload={onDownload}
+            onRename={onRename}
+            onProperties={onProperties}
+          />
         ))}
     </List>
   );

--- a/S3WebClient/src/components/ObjectFlatList.tsx
+++ b/S3WebClient/src/components/ObjectFlatList.tsx
@@ -16,7 +16,10 @@ export default function ObjectFlatList({
   onProperties,
 }: Props) {
   return (
-    <List disablePadding>
+    <List
+      disablePadding
+      sx={{ bgcolor: "background.paper", borderRadius: 1, boxShadow: 1 }}
+    >
       {items
         .sort((a, b) => a.key.localeCompare(b.key))
         .map((item) => (

--- a/S3WebClient/src/components/ObjectItemRow.tsx
+++ b/S3WebClient/src/components/ObjectItemRow.tsx
@@ -4,6 +4,7 @@ import {
   ListItemText,
   Menu,
   MenuItem,
+  IconButton,
 } from "@mui/material";
 import FolderIcon from "@mui/icons-material/Folder";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
@@ -12,6 +13,7 @@ import ImageIcon from "@mui/icons-material/Image";
 import type { S3ObjectEntity } from "../types/s3";
 import { useState } from "react";
 import type { ReactNode } from "react";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
 
 const getFileIcon = (key: string) => {
   const ext = key.split(".").pop()?.toLowerCase();
@@ -40,6 +42,7 @@ interface Props {
   onDownload?: (item: S3ObjectEntity) => void;
   onRename?: (item: S3ObjectEntity) => void;
   onProperties?: (item: S3ObjectEntity) => void;
+  selected?: boolean;
 }
 
 export default function ObjectItemRow({
@@ -51,36 +54,24 @@ export default function ObjectItemRow({
   onDownload,
   onRename,
   onProperties,
+  selected = false,
 }: Props) {
-  const [menuPos, setMenuPos] = useState<
-    | {
-        mouseX: number;
-        mouseY: number;
-      }
-    | null
-  >(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-  const handleContextMenu = (event: React.MouseEvent) => {
-    event.preventDefault();
-    setMenuPos(
-      menuPos === null
-        ? {
-            mouseX: event.clientX - 2,
-            mouseY: event.clientY - 4,
-          }
-        : null
-    );
+  const handleMenuOpen = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setAnchorEl(event.currentTarget as HTMLElement);
   };
 
   const handleClose = () => {
-    setMenuPos(null);
+    setAnchorEl(null);
   };
 
   return (
     <>
       <ListItemButton
         onClick={onClick}
-        onContextMenu={handleContextMenu}
+        selected={selected}
         sx={{ pl: depth * 2 }}
       >
         <ListItemIcon>
@@ -92,17 +83,16 @@ export default function ObjectItemRow({
         </ListItemIcon>
         <ListItemText primary={name} />
         {endIcon}
+        <IconButton
+          edge="end"
+          size="small"
+          onClick={handleMenuOpen}
+          sx={{ ml: 1 }}
+        >
+          <MoreVertIcon fontSize="small" />
+        </IconButton>
       </ListItemButton>
-      <Menu
-        open={menuPos !== null}
-        onClose={handleClose}
-        anchorReference="anchorPosition"
-        anchorPosition={
-          menuPos !== null
-            ? { top: menuPos.mouseY, left: menuPos.mouseX }
-            : undefined
-        }
-      >
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose} onClick={(e)=>e.stopPropagation()}>
         {item.isFolder === 0 && (
           <MenuItem
             onClick={() => {

--- a/S3WebClient/src/components/ObjectItemRow.tsx
+++ b/S3WebClient/src/components/ObjectItemRow.tsx
@@ -57,6 +57,7 @@ export default function ObjectItemRow({
   selected = false,
 }: Props) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const hasActions = onDownload || onRename || onProperties;
 
   const handleMenuOpen = (event: React.MouseEvent) => {
     event.stopPropagation();
@@ -83,43 +84,56 @@ export default function ObjectItemRow({
         </ListItemIcon>
         <ListItemText primary={name} />
         {endIcon}
-        <IconButton
-          edge="end"
-          size="small"
-          onClick={handleMenuOpen}
-          sx={{ ml: 1 }}
-        >
-          <MoreVertIcon fontSize="small" />
-        </IconButton>
-      </ListItemButton>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose} onClick={(e)=>e.stopPropagation()}>
-        {item.isFolder === 0 && (
-          <MenuItem
-            onClick={() => {
-              onDownload?.(item);
-              handleClose();
-            }}
+        {hasActions && (
+          <IconButton
+            edge="end"
+            size="small"
+            onClick={handleMenuOpen}
+            sx={{ ml: 1 }}
           >
-            Scarica
-          </MenuItem>
+            <MoreVertIcon fontSize="small" />
+          </IconButton>
         )}
-        <MenuItem
-          onClick={() => {
-            onRename?.(item);
-            handleClose();
-          }}
+      </ListItemButton>
+      {hasActions && (
+        <Menu
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={handleClose}
+          onClick={(e) => e.stopPropagation()}
         >
-          Rinomina
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            onProperties?.(item);
-            handleClose();
-          }}
-        >
-          Proprietà
-        </MenuItem>
-      </Menu>
+          {item.isFolder === 0 && onDownload && (
+            <MenuItem
+              onClick={() => {
+                onDownload(item);
+                handleClose();
+              }}
+            >
+              Scarica
+            </MenuItem>
+          )}
+          {onRename && (
+            <MenuItem
+              onClick={() => {
+                onRename(item);
+                handleClose();
+              }}
+            >
+              Rinomina
+            </MenuItem>
+          )}
+          {onProperties && (
+            <MenuItem
+              onClick={() => {
+                onProperties(item);
+                handleClose();
+              }}
+            >
+              Proprietà
+            </MenuItem>
+          )}
+        </Menu>
+      )}
     </>
   );
 }

--- a/S3WebClient/src/components/ObjectItemRow.tsx
+++ b/S3WebClient/src/components/ObjectItemRow.tsx
@@ -1,9 +1,16 @@
-import { ListItemButton, ListItemIcon, ListItemText } from "@mui/material";
+import {
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from "@mui/material";
 import FolderIcon from "@mui/icons-material/Folder";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
 import ImageIcon from "@mui/icons-material/Image";
 import type { S3ObjectEntity } from "../types/s3";
+import { useState } from "react";
 import type { ReactNode } from "react";
 
 const getFileIcon = (key: string) => {
@@ -30,6 +37,9 @@ interface Props {
   depth?: number;
   onClick?: () => void;
   endIcon?: ReactNode;
+  onDownload?: (item: S3ObjectEntity) => void;
+  onRename?: (item: S3ObjectEntity) => void;
+  onProperties?: (item: S3ObjectEntity) => void;
 }
 
 export default function ObjectItemRow({
@@ -38,18 +48,88 @@ export default function ObjectItemRow({
   depth = 0,
   onClick,
   endIcon,
+  onDownload,
+  onRename,
+  onProperties,
 }: Props) {
+  const [menuPos, setMenuPos] = useState<
+    | {
+        mouseX: number;
+        mouseY: number;
+      }
+    | null
+  >(null);
+
+  const handleContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault();
+    setMenuPos(
+      menuPos === null
+        ? {
+            mouseX: event.clientX - 2,
+            mouseY: event.clientY - 4,
+          }
+        : null
+    );
+  };
+
+  const handleClose = () => {
+    setMenuPos(null);
+  };
+
   return (
-    <ListItemButton onClick={onClick} sx={{ pl: depth * 2 }}>
-      <ListItemIcon>
-        {item.isFolder ? (
-          <FolderIcon sx={{ color: "primary.main" }} />
-        ) : (
-          getFileIcon(item.key)
+    <>
+      <ListItemButton
+        onClick={onClick}
+        onContextMenu={handleContextMenu}
+        sx={{ pl: depth * 2 }}
+      >
+        <ListItemIcon>
+          {item.isFolder ? (
+            <FolderIcon sx={{ color: "primary.main" }} />
+          ) : (
+            getFileIcon(item.key)
+          )}
+        </ListItemIcon>
+        <ListItemText primary={name} />
+        {endIcon}
+      </ListItemButton>
+      <Menu
+        open={menuPos !== null}
+        onClose={handleClose}
+        anchorReference="anchorPosition"
+        anchorPosition={
+          menuPos !== null
+            ? { top: menuPos.mouseY, left: menuPos.mouseX }
+            : undefined
+        }
+      >
+        {item.isFolder === 0 && (
+          <MenuItem
+            onClick={() => {
+              onDownload?.(item);
+              handleClose();
+            }}
+          >
+            Scarica
+          </MenuItem>
         )}
-      </ListItemIcon>
-      <ListItemText primary={name} />
-      {endIcon}
-    </ListItemButton>
+        <MenuItem
+          onClick={() => {
+            onRename?.(item);
+            handleClose();
+          }}
+        >
+          Rinomina
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            onProperties?.(item);
+            handleClose();
+          }}
+        >
+          Proprietà
+        </MenuItem>
+      </Menu>
+    </>
   );
 }

--- a/S3WebClient/src/components/ObjectItemRow.tsx
+++ b/S3WebClient/src/components/ObjectItemRow.tsx
@@ -5,6 +5,8 @@ import {
   Menu,
   MenuItem,
   IconButton,
+  Typography,
+  Box,
 } from "@mui/material";
 import FolderIcon from "@mui/icons-material/Folder";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
@@ -73,17 +75,39 @@ export default function ObjectItemRow({
       <ListItemButton
         onClick={onClick}
         selected={selected}
-        sx={{ pl: depth * 2 }}
+        sx={{ pl: depth * 2 + 2, borderBottom: "1px solid", borderColor: "divider" }}
       >
-        <ListItemIcon>
+        <ListItemIcon sx={{ minWidth: 32 }}>
           {item.isFolder ? (
             <FolderIcon sx={{ color: "primary.main" }} />
           ) : (
             getFileIcon(item.key)
           )}
         </ListItemIcon>
-        <ListItemText primary={name} />
-        {endIcon}
+        <ListItemText primary={name} sx={{ flex: 1 }} />
+        {!item.isFolder && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 2,
+              color: "text.secondary",
+              mr: endIcon || hasActions ? 1 : 0,
+            }}
+          >
+            {item.size !== undefined && (
+              <Typography variant="body2">
+                {(item.size / 1024).toFixed(1)} KB
+              </Typography>
+            )}
+            {item.lastModified && (
+              <Typography variant="body2">
+                {item.lastModified.toLocaleDateString()}
+              </Typography>
+            )}
+          </Box>
+        )}
+        {endIcon && <Box sx={{ mr: hasActions ? 1 : 0 }}>{endIcon}</Box>}
         {hasActions && (
           <IconButton
             edge="end"

--- a/S3WebClient/src/components/ObjectPropertiesDialog.tsx
+++ b/S3WebClient/src/components/ObjectPropertiesDialog.tsx
@@ -1,0 +1,54 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  List,
+  ListItem,
+  ListItemText,
+} from "@mui/material";
+import type { S3ObjectEntity } from "../types/s3";
+
+interface Props {
+  item: S3ObjectEntity | null;
+  onClose: () => void;
+}
+
+export default function ObjectPropertiesDialog({ item, onClose }: Props) {
+  return (
+    <Dialog open={!!item} onClose={onClose}>
+      <DialogTitle>Proprietà</DialogTitle>
+      <DialogContent>
+        {item && (
+          <List>
+            <ListItem>
+              <ListItemText
+                primary="Nome"
+                secondary={item.key.split("/").pop() || item.key}
+              />
+            </ListItem>
+            <ListItem>
+              <ListItemText primary="Percorso" secondary={item.key} />
+            </ListItem>
+            {item.size !== undefined && (
+              <ListItem>
+                <ListItemText
+                  primary="Dimensione"
+                  secondary={`${item.size} B`}
+                />
+              </ListItem>
+            )}
+            {item.lastModified && (
+              <ListItem>
+                <ListItemText
+                  primary="Ultima modifica"
+                  secondary={item.lastModified.toString()}
+                />
+              </ListItem>
+            )}
+          </List>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/S3WebClient/src/components/ObjectPropertiesDrawer.tsx
+++ b/S3WebClient/src/components/ObjectPropertiesDrawer.tsx
@@ -35,7 +35,7 @@ export default function ObjectPropertiesDrawer({ item, onClose }: Props) {
               <ListItem>
                 <ListItemText
                   primary="Dimensione"
-                  secondary={`${item.size} B`}
+                  secondary={`${(item.size / 1024).toFixed(1)} KB`}
                 />
               </ListItem>
             )}
@@ -43,7 +43,7 @@ export default function ObjectPropertiesDrawer({ item, onClose }: Props) {
               <ListItem>
                 <ListItemText
                   primary="Ultima modifica"
-                  secondary={item.lastModified.toString()}
+                  secondary={item.lastModified.toLocaleString()}
                 />
               </ListItem>
             )}

--- a/S3WebClient/src/components/ObjectPropertiesDrawer.tsx
+++ b/S3WebClient/src/components/ObjectPropertiesDrawer.tsx
@@ -1,7 +1,7 @@
 import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
+  Drawer,
+  Box,
+  Typography,
   List,
   ListItem,
   ListItemText,
@@ -13,11 +13,13 @@ interface Props {
   onClose: () => void;
 }
 
-export default function ObjectPropertiesDialog({ item, onClose }: Props) {
+export default function ObjectPropertiesDrawer({ item, onClose }: Props) {
   return (
-    <Dialog open={!!item} onClose={onClose}>
-      <DialogTitle>Proprietà</DialogTitle>
-      <DialogContent>
+    <Drawer anchor="right" open={!!item} onClose={onClose}>
+      <Box sx={{ width: 320, p: 2 }}>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          Proprietà
+        </Typography>
         {item && (
           <List>
             <ListItem>
@@ -47,8 +49,8 @@ export default function ObjectPropertiesDialog({ item, onClose }: Props) {
             )}
           </List>
         )}
-      </DialogContent>
-    </Dialog>
+      </Box>
+    </Drawer>
   );
 }
 

--- a/S3WebClient/src/components/ObjectTreeView.tsx
+++ b/S3WebClient/src/components/ObjectTreeView.tsx
@@ -11,6 +11,8 @@ interface Props {
   onDownload: (item: S3ObjectEntity) => void;
   onRename: (item: S3ObjectEntity) => void;
   onProperties: (item: S3ObjectEntity) => void;
+  selected: string;
+  onSelect: (prefix: string) => void;
 }
 
 interface NodeProps {
@@ -20,6 +22,8 @@ interface NodeProps {
   onDownload: (item: S3ObjectEntity) => void;
   onRename: (item: S3ObjectEntity) => void;
   onProperties: (item: S3ObjectEntity) => void;
+  selected: string;
+  onSelect: (prefix: string) => void;
 }
 
 function Node({
@@ -29,6 +33,8 @@ function Node({
   onDownload,
   onRename,
   onProperties,
+  selected,
+  onSelect,
 }: NodeProps) {
   const [open, setOpen] = useState(false);
   const [children, setChildren] = useState<S3ObjectEntity[]>([]);
@@ -36,6 +42,7 @@ function Node({
 
   const toggle = async () => {
     if (item.isFolder !== 1) return;
+    onSelect(item.key);
     if (!open && children.length === 0) {
       setLoading(true);
       const loaded = await loadChildren(item.key);
@@ -58,6 +65,7 @@ function Node({
         onDownload={onDownload}
         onRename={onRename}
         onProperties={onProperties}
+        selected={selected === item.key}
       />
       {item.isFolder === 1 && (
         <Collapse in={open} timeout="auto" unmountOnExit>
@@ -76,6 +84,8 @@ function Node({
                     onDownload={onDownload}
                     onRename={onRename}
                     onProperties={onProperties}
+                    selected={selected}
+                    onSelect={onSelect}
                   />
                 ))
             )}
@@ -92,6 +102,8 @@ export default function ObjectTreeView({
   onDownload,
   onRename,
   onProperties,
+  selected,
+  onSelect,
 }: Props) {
   return (
     <List disablePadding>
@@ -106,6 +118,8 @@ export default function ObjectTreeView({
             onDownload={onDownload}
             onRename={onRename}
             onProperties={onProperties}
+            selected={selected}
+            onSelect={onSelect}
           />
         ))}
     </List>

--- a/S3WebClient/src/components/ObjectTreeView.tsx
+++ b/S3WebClient/src/components/ObjectTreeView.tsx
@@ -8,15 +8,28 @@ import ObjectItemRow from "./ObjectItemRow";
 interface Props {
   rootItems: S3ObjectEntity[];
   loadChildren: (prefix: string) => Promise<S3ObjectEntity[]>;
+  onDownload: (item: S3ObjectEntity) => void;
+  onRename: (item: S3ObjectEntity) => void;
+  onProperties: (item: S3ObjectEntity) => void;
 }
 
 interface NodeProps {
   item: S3ObjectEntity;
   depth: number;
   loadChildren: (prefix: string) => Promise<S3ObjectEntity[]>;
+  onDownload: (item: S3ObjectEntity) => void;
+  onRename: (item: S3ObjectEntity) => void;
+  onProperties: (item: S3ObjectEntity) => void;
 }
 
-function Node({ item, depth, loadChildren }: NodeProps) {
+function Node({
+  item,
+  depth,
+  loadChildren,
+  onDownload,
+  onRename,
+  onProperties,
+}: NodeProps) {
   const [open, setOpen] = useState(false);
   const [children, setChildren] = useState<S3ObjectEntity[]>([]);
   const [loading, setLoading] = useState(false);
@@ -42,6 +55,9 @@ function Node({ item, depth, loadChildren }: NodeProps) {
         depth={depth}
         onClick={toggle}
         endIcon={item.isFolder === 1 ? open ? <ExpandLess /> : <ExpandMore /> : undefined}
+        onDownload={onDownload}
+        onRename={onRename}
+        onProperties={onProperties}
       />
       {item.isFolder === 1 && (
         <Collapse in={open} timeout="auto" unmountOnExit>
@@ -57,6 +73,9 @@ function Node({ item, depth, loadChildren }: NodeProps) {
                     item={child}
                     depth={depth + 1}
                     loadChildren={loadChildren}
+                    onDownload={onDownload}
+                    onRename={onRename}
+                    onProperties={onProperties}
                   />
                 ))
             )}
@@ -67,7 +86,13 @@ function Node({ item, depth, loadChildren }: NodeProps) {
   );
 }
 
-export default function ObjectTreeView({ rootItems, loadChildren }: Props) {
+export default function ObjectTreeView({
+  rootItems,
+  loadChildren,
+  onDownload,
+  onRename,
+  onProperties,
+}: Props) {
   return (
     <List disablePadding>
       {rootItems
@@ -78,6 +103,9 @@ export default function ObjectTreeView({ rootItems, loadChildren }: Props) {
             item={item}
             depth={0}
             loadChildren={loadChildren}
+            onDownload={onDownload}
+            onRename={onRename}
+            onProperties={onProperties}
           />
         ))}
     </List>

--- a/S3WebClient/src/components/ObjectTreeView.tsx
+++ b/S3WebClient/src/components/ObjectTreeView.tsx
@@ -71,7 +71,7 @@ function Node({
         <Collapse in={open} timeout="auto" unmountOnExit>
           <List component="div" disablePadding>
             {loading ? (
-              <ListItemText sx={{ pl: (depth + 1) * 2 }} primary="Caricamento..." />
+              <ListItemText sx={{ pl: (depth + 1) * 2 + 2 }} primary="Caricamento..." />
             ) : (
               children
                 .sort((a, b) => b.isFolder - a.isFolder || a.key.localeCompare(b.key))
@@ -106,7 +106,10 @@ export default function ObjectTreeView({
   onSelect,
 }: Props) {
   return (
-    <List disablePadding>
+    <List
+      disablePadding
+      sx={{ bgcolor: "background.paper", borderRadius: 1, boxShadow: 1 }}
+    >
       {rootItems
         .sort((a, b) => b.isFolder - a.isFolder || a.key.localeCompare(b.key))
         .map((item) => (

--- a/S3WebClient/src/components/ObjectTreeView.tsx
+++ b/S3WebClient/src/components/ObjectTreeView.tsx
@@ -8,9 +8,9 @@ import ObjectItemRow from "./ObjectItemRow";
 interface Props {
   rootItems: S3ObjectEntity[];
   loadChildren: (prefix: string) => Promise<S3ObjectEntity[]>;
-  onDownload: (item: S3ObjectEntity) => void;
-  onRename: (item: S3ObjectEntity) => void;
-  onProperties: (item: S3ObjectEntity) => void;
+  onDownload?: (item: S3ObjectEntity) => void;
+  onRename?: (item: S3ObjectEntity) => void;
+  onProperties?: (item: S3ObjectEntity) => void;
   selected: string;
   onSelect: (prefix: string) => void;
 }
@@ -19,9 +19,9 @@ interface NodeProps {
   item: S3ObjectEntity;
   depth: number;
   loadChildren: (prefix: string) => Promise<S3ObjectEntity[]>;
-  onDownload: (item: S3ObjectEntity) => void;
-  onRename: (item: S3ObjectEntity) => void;
-  onProperties: (item: S3ObjectEntity) => void;
+  onDownload?: (item: S3ObjectEntity) => void;
+  onRename?: (item: S3ObjectEntity) => void;
+  onProperties?: (item: S3ObjectEntity) => void;
   selected: string;
   onSelect: (prefix: string) => void;
 }

--- a/S3WebClient/src/components/RenameObjectDialog.tsx
+++ b/S3WebClient/src/components/RenameObjectDialog.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  DialogActions,
+  Button,
+} from "@mui/material";
+
+interface Props {
+  open: boolean;
+  currentName: string;
+  onCancel: () => void;
+  onConfirm: (newName: string) => void;
+}
+
+export default function RenameObjectDialog({
+  open,
+  currentName,
+  onCancel,
+  onConfirm,
+}: Props) {
+  const [name, setName] = useState(currentName);
+
+  useEffect(() => {
+    setName(currentName);
+  }, [currentName, open]);
+
+  return (
+    <Dialog open={open} onClose={onCancel}>
+      <DialogTitle>Rinomina</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          margin="dense"
+          fullWidth
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel}>Annulla</Button>
+        <Button onClick={() => onConfirm(name)} variant="contained">
+          Salva
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/S3WebClient/src/components/UploadObjectDialog.tsx
+++ b/S3WebClient/src/components/UploadObjectDialog.tsx
@@ -78,9 +78,16 @@ export default function UploadObjectDialog({ open, connection, onClose, onUpload
         <Typography variant="subtitle2" sx={{ mb: 1 }}>
           Seleziona cartella di destinazione
         </Typography>
-        <List disablePadding sx={{ maxHeight: 200, overflowY: "auto", mb: 2 }}>
-          <ListItemButton selected={selected === ""} onClick={() => setSelected("")}>
-            <ListItemIcon>
+        <List
+          disablePadding
+          sx={{ maxHeight: 200, overflowY: "auto", mb: 2, bgcolor: "background.paper", borderRadius: 1, boxShadow: 1 }}
+        >
+          <ListItemButton
+            selected={selected === ""}
+            onClick={() => setSelected("")}
+            sx={{ pl: 2 }}
+          >
+            <ListItemIcon sx={{ minWidth: 32 }}>
               <FolderIcon sx={{ color: "primary.main" }} />
             </ListItemIcon>
             <ListItemText primary="/" />
@@ -156,9 +163,9 @@ function FolderNode({ item, depth, selected, onSelect, loadFolders }: FolderNode
       <ListItemButton
         onClick={toggle}
         selected={selected === item.key}
-        sx={{ pl: depth * 2 }}
+        sx={{ pl: depth * 2 + 2 }}
       >
-        <ListItemIcon>
+        <ListItemIcon sx={{ minWidth: 32 }}>
           <FolderIcon sx={{ color: "primary.main" }} />
         </ListItemIcon>
         <ListItemText primary={name} />

--- a/S3WebClient/src/components/UploadObjectDialog.tsx
+++ b/S3WebClient/src/components/UploadObjectDialog.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState, useCallback } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Collapse,
+  Typography,
+} from "@mui/material";
+import FolderIcon from "@mui/icons-material/Folder";
+import ExpandLess from "@mui/icons-material/ExpandLess";
+import ExpandMore from "@mui/icons-material/ExpandMore";
+import type { S3Connection, S3ObjectEntity } from "../types/s3";
+import { s3ObjectRepository, objectRepository } from "../repositories";
+
+interface Props {
+  open: boolean;
+  connection: S3Connection;
+  onClose: () => void;
+  onUploaded: () => Promise<void> | void;
+}
+
+export default function UploadObjectDialog({ open, connection, onClose, onUploaded }: Props) {
+  const [rootFolders, setRootFolders] = useState<S3ObjectEntity[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+
+  const loadFolders = useCallback(
+    async (prefix: string) => {
+      const all = await s3ObjectRepository.list(connection, prefix);
+      return all.filter((i) => i.isFolder === 1);
+    },
+    [connection]
+  );
+
+  useEffect(() => {
+    if (open) {
+      (async () => {
+        const folders = await loadFolders("");
+        setRootFolders(folders);
+        setSelected(null);
+        setFile(null);
+      })();
+    }
+  }, [open, loadFolders]);
+
+  const handleUpload = async () => {
+    if (!file || selected === null) return;
+    const key = `${selected}${file.name}`;
+    try {
+      await s3ObjectRepository.upload(connection, key, file);
+      await objectRepository.save([
+        {
+          connectionId: connection.id,
+          key,
+          parent: selected,
+          isFolder: 0,
+          size: file.size,
+          lastModified: new Date(),
+        },
+      ]);
+      await onUploaded();
+      onClose();
+    } catch (err) {
+      console.error("Upload failed", err);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Carica file</DialogTitle>
+      <DialogContent dividers>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Seleziona cartella di destinazione
+        </Typography>
+        <List disablePadding sx={{ maxHeight: 200, overflowY: "auto", mb: 2 }}>
+          <ListItemButton selected={selected === ""} onClick={() => setSelected("")}>
+            <ListItemIcon>
+              <FolderIcon sx={{ color: "primary.main" }} />
+            </ListItemIcon>
+            <ListItemText primary="/" />
+          </ListItemButton>
+          {rootFolders.map((f) => (
+            <FolderNode
+              key={f.key}
+              item={f}
+              depth={1}
+              selected={selected ?? ""}
+              onSelect={setSelected}
+              loadFolders={loadFolders}
+            />
+          ))}
+        </List>
+        <Button
+          variant="outlined"
+          component="label"
+          disabled={selected === null}
+        >
+          Scegli file
+          <input
+            type="file"
+            hidden
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+          />
+        </Button>
+        {file && (
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            {file.name}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Annulla</Button>
+        <Button
+          onClick={handleUpload}
+          variant="contained"
+          disabled={!file || selected === null}
+        >
+          Carica
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+interface FolderNodeProps {
+  item: S3ObjectEntity;
+  depth: number;
+  selected: string;
+  onSelect: (prefix: string) => void;
+  loadFolders: (prefix: string) => Promise<S3ObjectEntity[]>;
+}
+
+function FolderNode({ item, depth, selected, onSelect, loadFolders }: FolderNodeProps) {
+  const [open, setOpen] = useState(false);
+  const [children, setChildren] = useState<S3ObjectEntity[]>([]);
+
+  const toggle = async () => {
+    onSelect(item.key);
+    if (!open && children.length === 0) {
+      const loaded = await loadFolders(item.key);
+      setChildren(loaded);
+    }
+    setOpen(!open);
+  };
+
+  const name = item.key.slice(item.parent.length).replace(/\/$/, "");
+
+  return (
+    <>
+      <ListItemButton
+        onClick={toggle}
+        selected={selected === item.key}
+        sx={{ pl: depth * 2 }}
+      >
+        <ListItemIcon>
+          <FolderIcon sx={{ color: "primary.main" }} />
+        </ListItemIcon>
+        <ListItemText primary={name} />
+        {open ? <ExpandLess /> : <ExpandMore />}
+      </ListItemButton>
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <List component="div" disablePadding>
+          {children.map((child) => (
+            <FolderNode
+              key={child.key}
+              item={child}
+              depth={depth + 1}
+              selected={selected}
+              onSelect={onSelect}
+              loadFolders={loadFolders}
+            />
+          ))}
+        </List>
+      </Collapse>
+    </>
+  );
+}

--- a/S3WebClient/src/components/UploadObjectDialog.tsx
+++ b/S3WebClient/src/components/UploadObjectDialog.tsx
@@ -16,7 +16,7 @@ import FolderIcon from "@mui/icons-material/Folder";
 import ExpandLess from "@mui/icons-material/ExpandLess";
 import ExpandMore from "@mui/icons-material/ExpandMore";
 import type { S3Connection, S3ObjectEntity } from "../types/s3";
-import { s3ObjectRepository, objectRepository } from "../repositories";
+import { objectService } from "../repositories";
 
 interface Props {
   open: boolean;
@@ -32,7 +32,7 @@ export default function UploadObjectDialog({ open, connection, onClose, onUpload
 
   const loadFolders = useCallback(
     async (prefix: string) => {
-      const all = await s3ObjectRepository.list(connection, prefix);
+      const all = await objectService.fetchChildren(connection, prefix);
       return all.filter((i) => i.isFolder === 1);
     },
     [connection]
@@ -53,17 +53,7 @@ export default function UploadObjectDialog({ open, connection, onClose, onUpload
     if (!file || selected === null) return;
     const key = `${selected}${file.name}`;
     try {
-      await s3ObjectRepository.upload(connection, key, file);
-      await objectRepository.save([
-        {
-          connectionId: connection.id,
-          key,
-          parent: selected,
-          isFolder: 0,
-          size: file.size,
-          lastModified: new Date(),
-        },
-      ]);
+      await objectService.upload(connection, key, file);
       await onUploaded();
       onClose();
     } catch (err) {

--- a/S3WebClient/src/repositories/index.ts
+++ b/S3WebClient/src/repositories/index.ts
@@ -2,8 +2,15 @@ import { dexieDb } from "../database/database";
 import { DexieConnectionRepository } from "./connectionRepository";
 import { DexieActivityRepository } from "./activityRepository";
 import { DexieObjectRepository } from "./objectRepository";
-export { s3ObjectRepository } from "./s3ObjectRepository";
+import { S3ObjectRepository } from "./s3ObjectRepository";
+import { ObjectService } from "./objectService";
 
 export const connectionRepository = new DexieConnectionRepository(dexieDb);
 export const activityRepository = new DexieActivityRepository(dexieDb);
 export const objectRepository = new DexieObjectRepository(dexieDb);
+
+const remoteObjectRepository = new S3ObjectRepository();
+export const objectService = new ObjectService(
+  remoteObjectRepository,
+  objectRepository
+);

--- a/S3WebClient/src/repositories/index.ts
+++ b/S3WebClient/src/repositories/index.ts
@@ -2,6 +2,7 @@ import { dexieDb } from "../database/database";
 import { DexieConnectionRepository } from "./connectionRepository";
 import { DexieActivityRepository } from "./activityRepository";
 import { DexieObjectRepository } from "./objectRepository";
+export { s3ObjectRepository } from "./s3ObjectRepository";
 
 export const connectionRepository = new DexieConnectionRepository(dexieDb);
 export const activityRepository = new DexieActivityRepository(dexieDb);

--- a/S3WebClient/src/repositories/objectService.ts
+++ b/S3WebClient/src/repositories/objectService.ts
@@ -1,0 +1,51 @@
+import type { S3Connection } from "../types/s3";
+import type { S3ObjectEntity } from "../types/s3";
+import { S3ObjectRepository } from "./s3ObjectRepository";
+import { DexieObjectRepository } from "./objectRepository";
+
+export class ObjectService {
+  private remote: S3ObjectRepository;
+  private local: DexieObjectRepository;
+
+  constructor(remote: S3ObjectRepository, local: DexieObjectRepository) {
+    this.remote = remote;
+    this.local = local;
+  }
+
+  async fetchChildren(connection: S3Connection, prefix: string): Promise<S3ObjectEntity[]> {
+    const all = await this.remote.list(connection, prefix);
+    await this.local.save(all);
+    return all;
+  }
+
+  async refreshAll(connection: S3Connection): Promise<S3ObjectEntity[]> {
+    const all = await this.remote.listAll(connection);
+    await this.local.replaceAll(connection.id, all);
+    return all;
+  }
+
+  async download(connection: S3Connection, key: string): Promise<Uint8Array | undefined> {
+    return await this.remote.download(connection, key);
+  }
+
+  async rename(connection: S3Connection, oldKey: string, newKey: string): Promise<void> {
+    await this.remote.rename(connection, oldKey, newKey);
+    // Refresh local cache after rename to keep paths in sync
+    await this.refreshAll(connection);
+  }
+
+  async upload(connection: S3Connection, key: string, file: File): Promise<void> {
+    await this.remote.upload(connection, key, file);
+    const parent = key.slice(0, key.lastIndexOf("/") + 1);
+    await this.local.save([
+      {
+        connectionId: connection.id,
+        key,
+        parent,
+        isFolder: 0,
+        size: file.size,
+        lastModified: new Date(),
+      },
+    ]);
+  }
+}

--- a/S3WebClient/src/repositories/s3ObjectRepository.ts
+++ b/S3WebClient/src/repositories/s3ObjectRepository.ts
@@ -1,0 +1,137 @@
+import { S3Client, ListObjectsV2Command, GetObjectCommand, CopyObjectCommand, DeleteObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import type { S3Connection, S3ObjectEntity } from "../types/s3";
+
+function createClient(connection: S3Connection) {
+  return new S3Client({
+    endpoint: connection.endpoint,
+    region: connection.region || "us-east-1",
+    forcePathStyle: connection.pathStyle === 1,
+    credentials: {
+      accessKeyId: connection.accessKeyId,
+      secretAccessKey: connection.secretAccessKey,
+    },
+  });
+}
+
+export class S3ObjectRepository {
+  async list(connection: S3Connection, prefix: string): Promise<S3ObjectEntity[]> {
+    const client = createClient(connection);
+    const folders: S3ObjectEntity[] = [];
+    const files: S3ObjectEntity[] = [];
+    let token: string | undefined;
+    do {
+      const res = await client.send(
+        new ListObjectsV2Command({
+          Bucket: connection.bucketName,
+          Prefix: prefix,
+          Delimiter: "/",
+          ContinuationToken: token,
+        })
+      );
+      (res.CommonPrefixes ?? []).forEach((p) => {
+        if (!p.Prefix) return;
+        folders.push({
+          connectionId: connection.id,
+          key: p.Prefix,
+          parent: prefix,
+          isFolder: 1,
+          size: 0,
+        });
+      });
+      (res.Contents ?? []).forEach((o) => {
+        if (!o.Key || o.Key === prefix) return;
+        files.push({
+          connectionId: connection.id,
+          key: o.Key,
+          parent: prefix,
+          isFolder: 0,
+          size: o.Size ?? 0,
+          lastModified: o.LastModified,
+        });
+      });
+      token = res.IsTruncated ? res.NextContinuationToken : undefined;
+    } while (token);
+    return [...folders, ...files];
+  }
+
+  async download(connection: S3Connection, key: string): Promise<Uint8Array | undefined> {
+    const client = createClient(connection);
+    const res = await client.send(
+      new GetObjectCommand({ Bucket: connection.bucketName, Key: key })
+    );
+    return await res.Body?.transformToByteArray();
+  }
+
+  async listAll(connection: S3Connection): Promise<S3ObjectEntity[]> {
+    const client = createClient(connection);
+    const folders: S3ObjectEntity[] = [];
+    const files: S3ObjectEntity[] = [];
+    const seenFolders = new Set<string>();
+    let token: string | undefined;
+    do {
+      const res = await client.send(
+        new ListObjectsV2Command({
+          Bucket: connection.bucketName,
+          ContinuationToken: token,
+        })
+      );
+      (res.Contents ?? []).forEach((o) => {
+        if (!o.Key) return;
+        const parts = o.Key.split("/");
+        let prefix = "";
+        for (let i = 0; i < parts.length - 1; i++) {
+          const folderKey = `${prefix}${parts[i]}/`;
+          if (!seenFolders.has(folderKey)) {
+            seenFolders.add(folderKey);
+            folders.push({
+              connectionId: connection.id,
+              key: folderKey,
+              parent: prefix,
+              isFolder: 1,
+              size: 0,
+            });
+          }
+          prefix = folderKey;
+        }
+        if (o.Key.endsWith("/")) return;
+        files.push({
+          connectionId: connection.id,
+          key: o.Key,
+          parent: prefix,
+          isFolder: 0,
+          size: o.Size ?? 0,
+          lastModified: o.LastModified,
+        });
+      });
+      token = res.IsTruncated ? res.NextContinuationToken : undefined;
+    } while (token);
+    return [...folders, ...files];
+  }
+
+  async rename(connection: S3Connection, oldKey: string, newKey: string): Promise<void> {
+    const client = createClient(connection);
+    await client.send(
+      new CopyObjectCommand({
+        Bucket: connection.bucketName,
+        CopySource: `${connection.bucketName}/${encodeURIComponent(oldKey)}`,
+        Key: newKey,
+      })
+    );
+    await client.send(
+      new DeleteObjectCommand({ Bucket: connection.bucketName, Key: oldKey })
+    );
+  }
+
+  async upload(connection: S3Connection, key: string, file: File): Promise<void> {
+    const client = createClient(connection);
+    await client.send(
+      new PutObjectCommand({
+        Bucket: connection.bucketName,
+        Key: key,
+        Body: file,
+      })
+    );
+  }
+}
+
+export const s3ObjectRepository = new S3ObjectRepository();

--- a/S3WebClient/src/repositories/s3ObjectRepository.ts
+++ b/S3WebClient/src/repositories/s3ObjectRepository.ts
@@ -124,11 +124,12 @@ export class S3ObjectRepository {
 
   async upload(connection: S3Connection, key: string, file: File): Promise<void> {
     const client = createClient(connection);
+    const body = new Uint8Array(await file.arrayBuffer());
     await client.send(
       new PutObjectCommand({
         Bucket: connection.bucketName,
         Key: key,
-        Body: file,
+        Body: body,
       })
     );
   }


### PR DESCRIPTION
## Summary
- add upload capability with folder selection on bucket page
- enable download, rename and property dialog via context menu
- wire S3 and local DB updates for file operations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Preprocessor dependency "sass-embedded" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8879ffec08320bac434c32c7f3667