### PR TITLE
Add dark mode and realtime connection checks

### DIFF
--- a/S3WebClient/src/App.tsx
+++ b/S3WebClient/src/App.tsx
@@ -6,8 +6,13 @@ import Settings from "./pages/Settings";
 import Profile from "./pages/Profile";
 import Bucket from "./pages/Bucket";
 import styles from "./App.module.scss";
+import { useSettings } from "./contexts/SettingsContext";
+import useRealtimeConnectionCheck from "./hooks/useRealtimeConnectionCheck";
 
 function App() {
+  const { settings } = useSettings();
+  useRealtimeConnectionCheck(settings.realtimeCheck, settings.realtimeInterval);
+
   return (
     <div className={styles.app}>
       <Layout>

--- a/S3WebClient/src/contexts/SettingsContext.tsx
+++ b/S3WebClient/src/contexts/SettingsContext.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState } from "react";
+
+export interface Settings {
+  notifications: boolean;
+  darkMode: boolean;
+  debugMode: boolean;
+  language: string;
+  theme: string;
+  realtimeCheck: boolean;
+  realtimeInterval: number; // seconds
+}
+
+const defaultSettings: Settings = {
+  notifications: true,
+  darkMode: false,
+  debugMode: false,
+  language: "it",
+  theme: "default",
+  realtimeCheck: false,
+  realtimeInterval: 60,
+};
+
+interface SettingsContextValue {
+  settings: Settings;
+  setSetting: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue>({
+  settings: defaultSettings,
+  setSetting: () => undefined,
+});
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [settings, setSettings] = useState<Settings>(() => {
+    try {
+      const stored = localStorage.getItem("settings");
+      return stored ? { ...defaultSettings, ...JSON.parse(stored) } : defaultSettings;
+    } catch {
+      return defaultSettings;
+    }
+  });
+
+  const setSetting: SettingsContextValue["setSetting"] = (key, value) => {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+  };
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("settings", JSON.stringify(settings));
+    } catch {
+      // ignore write errors
+    }
+  }, [settings]);
+
+  return (
+    <SettingsContext.Provider value={{ settings, setSetting }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => useContext(SettingsContext);
+

--- a/S3WebClient/src/hooks/useRealtimeConnectionCheck.ts
+++ b/S3WebClient/src/hooks/useRealtimeConnectionCheck.ts
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import { S3Client, HeadBucketCommand } from "@aws-sdk/client-s3";
+import {
+  connectionRepository,
+} from "../repositories";
+import type {
+  S3Connection,
+  ConnectionTestResult,
+} from "../types/s3";
+
+async function performTest(connection: S3Connection): Promise<ConnectionTestResult> {
+  try {
+    const client = new S3Client({
+      endpoint: connection.endpoint,
+      region: connection.region || "us-east-1",
+      forcePathStyle: connection.pathStyle === 1,
+      credentials: {
+        accessKeyId: connection.accessKeyId,
+        secretAccessKey: connection.secretAccessKey,
+      },
+    });
+    try {
+      await client.send(new HeadBucketCommand({ Bucket: connection.bucketName }));
+      return {
+        success: true,
+        message: "Connessione testata con successo",
+        timestamp: new Date(),
+      };
+    } catch (err: unknown) {
+      const e = err as { $metadata?: { httpStatusCode?: number }; name?: string; message?: string };
+      let message = "Errore nel test della connessione";
+      if (e.$metadata?.httpStatusCode === 404 || e.name === "NotFound") {
+        message = "Bucket non trovato";
+      }
+      return {
+        success: false,
+        message,
+        timestamp: new Date(),
+        error: e.message ?? "Errore sconosciuto",
+      };
+    }
+  } catch (err) {
+    return {
+      success: false,
+      message: "Errore nel test della connessione",
+      timestamp: new Date(),
+      error: err instanceof Error ? err.message : "Errore sconosciuto",
+    };
+  }
+}
+
+export function useRealtimeConnectionCheck(
+  enabled: boolean,
+  intervalSeconds: number
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    const interval = setInterval(async () => {
+      const connections = await connectionRepository.getAll();
+      for (const conn of connections) {
+        const result = await performTest(conn);
+        await connectionRepository.test(conn.id, result);
+      }
+    }, Math.max(1, intervalSeconds) * 1000);
+    return () => clearInterval(interval);
+  }, [enabled, intervalSeconds]);
+}
+
+export default useRealtimeConnectionCheck;
+

--- a/S3WebClient/src/main.tsx
+++ b/S3WebClient/src/main.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -5,31 +6,42 @@ import { ThemeProvider, createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import "./index.scss";
 import App from "./App.tsx";
+import { SettingsProvider, useSettings } from "./contexts/SettingsContext";
 
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: "#1976d2",
+function ThemedApp() {
+  const { settings } = useSettings();
+  const theme = createTheme({
+    palette: {
+      mode: settings.darkMode ? "dark" : "light",
+      primary: {
+        main: "#1976d2",
+      },
+      secondary: {
+        main: "#dc004e",
+      },
     },
-    secondary: {
-      main: "#dc004e",
+    typography: {
+      fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+      fontSize: 13,
+      htmlFontSize: 14,
     },
-  },
-  typography: {
-    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
-    fontSize: 13,
-    htmlFontSize: 14,
-  },
-  spacing: 7,
-});
+    spacing: 7,
+  });
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
+  );
+}
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <App />
-      </ThemeProvider>
+      <SettingsProvider>
+        <ThemedApp />
+      </SettingsProvider>
     </BrowserRouter>
   </StrictMode>
 );

--- a/S3WebClient/src/pages/Settings.tsx
+++ b/S3WebClient/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import {
   ListItemText,
   Chip,
   Button,
+  TextField,
 } from "@mui/material";
 import {
   Settings as SettingsIcon,
@@ -20,24 +21,16 @@ import {
   Cloud,
   Info,
 } from "@mui/icons-material";
-import { useState } from "react";
+import { useSettings } from "../contexts/SettingsContext";
 
 export default function Settings() {
-  const [settings, setSettings] = useState({
-    autoSave: true,
-    notifications: true,
-    darkMode: false,
-    autoConnect: false,
-    debugMode: false,
-    language: "it",
-    theme: "default",
-  });
+  const { settings, setSetting } = useSettings();
 
-  const handleSettingChange = (
-    setting: keyof typeof settings,
-    value: boolean
+  const handleSettingChange = <K extends keyof typeof settings>(
+    setting: K,
+    value: (typeof settings)[K]
   ) => {
-    setSettings((prev) => ({ ...prev, [setting]: value }));
+    setSetting(setting, value);
   };
 
   const settingCategories = [
@@ -46,19 +39,12 @@ export default function Settings() {
       icon: <SettingsIcon />,
       settings: [
         {
-          key: "autoSave",
-          label: "Salvataggio Automatico",
-          description: "Salva automaticamente le modifiche alle connessioni",
-          type: "switch",
-          value: settings.autoSave,
-        },
-        {
-          key: "autoConnect",
-          label: "Connessione Automatica",
+          key: "realtimeCheck",
+          label: "Verifica connessioni in realtime",
           description:
-            "Connetti automaticamente all'ultima connessione utilizzata",
+            "Controlla periodicamente lo stato delle connessioni",
           type: "switch",
-          value: settings.autoConnect,
+          value: settings.realtimeCheck,
         },
       ],
     },
@@ -241,13 +227,31 @@ export default function Settings() {
                             </Box>
                           }
                           secondary={
-                            <Typography
-                              variant="body2"
-                              color="text.secondary"
-                              sx={{ mt: 0.5, fontSize: "0.875rem" }}
-                            >
-                              {setting.description}
-                            </Typography>
+                            <Box sx={{ mt: 0.5 }}>
+                              <Typography
+                                variant="body2"
+                                color="text.secondary"
+                                sx={{ fontSize: "0.875rem" }}
+                              >
+                                {setting.description}
+                              </Typography>
+                              {setting.key === "realtimeCheck" && settings.realtimeCheck && (
+                                <TextField
+                                  type="number"
+                                  label="Intervallo (s)"
+                                  size="small"
+                                  value={settings.realtimeInterval}
+                                  onChange={(e) =>
+                                    handleSettingChange(
+                                      "realtimeInterval",
+                                      parseInt(e.target.value, 10) || 0
+                                    )
+                                  }
+                                  sx={{ mt: 1, width: 140 }}
+                                  inputProps={{ min: 1 }}
+                                />
+                              )}
+                            </Box>
                           }
                         />
                         {setting.type === "switch" && (


### PR DESCRIPTION
## Summary
- add settings context with dark mode and realtime connection options
- enable dark theme and realtime connection tests when configured
- allow user to configure realtime connection polling interval

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Cannot find name 'describe' in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d3fda69c8320a3de42e0d16a509c