### PR TITLE
Enhance sidebar aesthetics

### DIFF
--- a/S3WebClient/src/App.tsx
+++ b/S3WebClient/src/App.tsx
@@ -5,6 +5,7 @@ import Buckets from "./pages/Buckets";
 import Settings from "./pages/Settings";
 import Profile from "./pages/Profile";
 import Bucket from "./pages/Bucket";
+import Notifications from "./pages/Notifications";
 import styles from "./App.module.scss";
 import { useSettings } from "./contexts/SettingsContext";
 import useRealtimeConnectionCheck from "./hooks/useRealtimeConnectionCheck";
@@ -22,6 +23,7 @@ function App() {
           <Route path="/bucket/:id" element={<Bucket />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/profile" element={<Profile />} />
+          <Route path="/notifications" element={<Notifications />} />
         </Routes>
       </Layout>
     </div>

--- a/S3WebClient/src/components/Layout.tsx
+++ b/S3WebClient/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import {
   AppBar,
   Box,
   CssBaseline,
+  Divider,
   Drawer,
   IconButton,
   List,
@@ -13,6 +14,7 @@ import {
   ListItemText,
   Toolbar,
   Typography,
+  alpha,
   useTheme,
 } from "@mui/material";
 import {
@@ -52,37 +54,59 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   };
 
   const drawer = (
-    <Box>
-      <Toolbar>
-        <Typography
-          variant="h6"
-          noWrap
-          component="div"
-          sx={{ fontWeight: "bold" }}
-        >
+    <Box height="100%">
+      <Toolbar
+        sx={{
+          background: `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
+          color: theme.palette.primary.contrastText,
+        }}
+      >
+        <Typography variant="h6" noWrap component="div" sx={{ fontWeight: "bold" }}>
           S3 Web Client
         </Typography>
       </Toolbar>
-      <List>
+      <Divider />
+      <List sx={{ mt: 1 }}>
         {menuItems.map((item) => (
           <ListItem key={item.text} disablePadding>
             <ListItemButton
               onClick={() => handleMenuClick(item.path)}
               selected={location.pathname === item.path}
               sx={{
-                "&:hover": {
-                  backgroundColor: theme.palette.action.hover,
-                },
-                "&.Mui-selected": {
-                  backgroundColor: theme.palette.primary.light + "20",
-                  borderRight: `3px solid ${theme.palette.primary.main}`,
-                },
-                borderRadius: 1,
+                position: "relative",
                 mx: 1,
                 mb: 0.5,
+                borderRadius: 2,
+                "&:hover": {
+                  backgroundColor: alpha(theme.palette.primary.main, 0.08),
+                },
+                "&.Mui-selected": {
+                  backgroundColor: alpha(theme.palette.primary.main, 0.15),
+                  "& .MuiListItemIcon-root": {
+                    color: theme.palette.primary.main,
+                  },
+                  "&:before": {
+                    content: '""',
+                    position: "absolute",
+                    left: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: 4,
+                    borderTopLeftRadius: 2,
+                    borderBottomLeftRadius: 2,
+                    backgroundColor: theme.palette.primary.main,
+                  },
+                },
               }}
             >
-              <ListItemIcon sx={{ color: theme.palette.primary.main }}>
+              <ListItemIcon
+                sx={{
+                  color:
+                    location.pathname === item.path
+                      ? theme.palette.primary.main
+                      : theme.palette.text.secondary,
+                }}
+              >
                 {item.icon}
               </ListItemIcon>
               <ListItemText
@@ -162,8 +186,10 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             "& .MuiDrawer-paper": {
               boxSizing: "border-box",
               width: drawerWidth,
-              backgroundColor: theme.palette.background.paper,
-              borderRight: `1px solid ${theme.palette.divider}`,
+              background: theme.palette.background.paper,
+              backgroundImage: `linear-gradient(to bottom, ${theme.palette.background.paper}, ${alpha(theme.palette.primary.light, 0.05)})`,
+              borderRight: "none",
+              boxShadow: "2px 0 8px rgba(0,0,0,0.05)",
             },
           }}
         >
@@ -178,8 +204,10 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             "& .MuiDrawer-paper": {
               boxSizing: "border-box",
               width: drawerWidth,
-              backgroundColor: theme.palette.background.paper,
-              borderRight: `1px solid ${theme.palette.divider}`,
+              background: theme.palette.background.paper,
+              backgroundImage: `linear-gradient(to bottom, ${theme.palette.background.paper}, ${alpha(theme.palette.primary.light, 0.05)})`,
+              borderRight: "none",
+              boxShadow: "2px 0 8px rgba(0,0,0,0.05)",
             },
           }}
           open

--- a/S3WebClient/src/components/Layout.tsx
+++ b/S3WebClient/src/components/Layout.tsx
@@ -16,6 +16,7 @@ import {
   Typography,
   alpha,
   useTheme,
+  Badge,
 } from "@mui/material";
 import {
   Menu as MenuIcon,
@@ -23,6 +24,8 @@ import {
   Storage,
   Settings,
   AccountCircle,
+  CloudQueue,
+  NotificationsNone,
 } from "@mui/icons-material";
 
 const drawerWidth = 252;
@@ -61,9 +64,12 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           color: theme.palette.primary.contrastText,
         }}
       >
-        <Typography variant="h6" noWrap component="div" sx={{ fontWeight: "bold" }}>
-          S3 Web Client
-        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <CloudQueue sx={{ mr: 1 }} />
+          <Typography variant="h6" noWrap component="div" sx={{ fontWeight: "bold" }}>
+            S3 Web Client
+          </Typography>
+        </Box>
       </Toolbar>
       <Divider />
       <List sx={{ mt: 1 }}>
@@ -161,9 +167,21 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
-            S3 Web Client
-          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center", flexGrow: 1 }}>
+            <CloudQueue sx={{ mr: 1 }} />
+            <Typography variant="h6" noWrap component="div">
+              S3 Web Client
+            </Typography>
+          </Box>
+          <IconButton
+            color="inherit"
+            aria-label="notifications"
+            onClick={() => navigate("/notifications")}
+          >
+            <Badge badgeContent={0} color="primary">
+              <NotificationsNone />
+            </Badge>
+          </IconButton>
         </Toolbar>
       </AppBar>
 

--- a/S3WebClient/src/components/Layout.tsx
+++ b/S3WebClient/src/components/Layout.tsx
@@ -27,6 +27,7 @@ import {
   CloudQueue,
   NotificationsNone,
 } from "@mui/icons-material";
+import { useNotifications } from "../contexts/NotificationsContext";
 
 const drawerWidth = 252;
 
@@ -36,9 +37,11 @@ interface LayoutProps {
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   const [mobileOpen, setMobileOpen] = React.useState(false);
+  const [notifOpen, setNotifOpen] = React.useState(false);
   const theme = useTheme();
   const navigate = useNavigate();
   const location = useLocation();
+  const { notifications } = useNotifications();
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
@@ -176,9 +179,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           <IconButton
             color="inherit"
             aria-label="notifications"
-            onClick={() => navigate("/notifications")}
+            onClick={() => setNotifOpen(true)}
           >
-            <Badge badgeContent={0} color="primary">
+            <Badge badgeContent={notifications.length} color="primary">
               <NotificationsNone />
             </Badge>
           </IconButton>
@@ -266,6 +269,42 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           {children}
         </Box>
       </Box>
+      <Drawer
+        anchor="right"
+        open={notifOpen}
+        onClose={() => setNotifOpen(false)}
+        sx={{ "& .MuiDrawer-paper": { width: 320 } }}
+      >
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Notifications
+          </Typography>
+        </Toolbar>
+        <Divider />
+        <List>
+          {notifications.slice(0, 10).map((n) => (
+            <ListItem key={n.id}>
+              <ListItemText
+                primary={n.message}
+                secondary={n.date.toLocaleString()}
+              />
+            </ListItem>
+          ))}
+        </List>
+        <Divider />
+        <List>
+          <ListItem disablePadding>
+            <ListItemButton
+              onClick={() => {
+                navigate("/notifications");
+                setNotifOpen(false);
+              }}
+            >
+              <ListItemText primary="View all" />
+            </ListItemButton>
+          </ListItem>
+        </List>
+      </Drawer>
     </Box>
   );
 };

--- a/S3WebClient/src/contexts/NotificationsContext.tsx
+++ b/S3WebClient/src/contexts/NotificationsContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useState } from "react";
+
+export interface NotificationItem {
+  id: number;
+  message: string;
+  date: Date;
+}
+
+interface NotificationsContextValue {
+  notifications: NotificationItem[];
+  addNotification: (message: string) => void;
+}
+
+const NotificationsContext = createContext<NotificationsContextValue>({
+  notifications: [],
+  addNotification: () => undefined,
+});
+
+export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+
+  const addNotification: NotificationsContextValue["addNotification"] = (message) => {
+    setNotifications((prev) => [{ id: Date.now(), message, date: new Date() }, ...prev]);
+  };
+
+  return (
+    <NotificationsContext.Provider value={{ notifications, addNotification }}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+};
+
+export const useNotifications = () => useContext(NotificationsContext);

--- a/S3WebClient/src/main.tsx
+++ b/S3WebClient/src/main.tsx
@@ -7,6 +7,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import "./index.scss";
 import App from "./App.tsx";
 import { SettingsProvider, useSettings } from "./contexts/SettingsContext";
+import { NotificationsProvider } from "./contexts/NotificationsContext";
 
 function ThemedApp() {
   const { settings } = useSettings();
@@ -51,7 +52,9 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <SettingsProvider>
-        <ThemedApp />
+        <NotificationsProvider>
+          <ThemedApp />
+        </NotificationsProvider>
       </SettingsProvider>
     </BrowserRouter>
   </StrictMode>

--- a/S3WebClient/src/pages/Notifications.tsx
+++ b/S3WebClient/src/pages/Notifications.tsx
@@ -1,12 +1,28 @@
-import { Box, Typography } from "@mui/material";
+import { Box, List, ListItem, ListItemText, Typography } from "@mui/material";
+import { useNotifications } from "../contexts/NotificationsContext";
 
 const Notifications = () => {
+  const { notifications } = useNotifications();
+
   return (
     <Box p={3}>
       <Typography variant="h5" gutterBottom>
         Notifications
       </Typography>
-      <Typography variant="body1">No notifications yet.</Typography>
+      {notifications.length === 0 ? (
+        <Typography variant="body1">No notifications yet.</Typography>
+      ) : (
+        <List>
+          {notifications.map((n) => (
+            <ListItem key={n.id}>
+              <ListItemText
+                primary={n.message}
+                secondary={n.date.toLocaleString()}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
     </Box>
   );
 };

--- a/S3WebClient/src/pages/Notifications.tsx
+++ b/S3WebClient/src/pages/Notifications.tsx
@@ -1,0 +1,14 @@
+import { Box, Typography } from "@mui/material";
+
+const Notifications = () => {
+  return (
+    <Box p={3}>
+      <Typography variant="h5" gutterBottom>
+        Notifications
+      </Typography>
+      <Typography variant="body1">No notifications yet.</Typography>
+    </Box>
+  );
+};
+
+export default Notifications;


### PR DESCRIPTION
## Summary
- Revamp navigation drawer with gradient header and polished menu item styling for better UX.
- Apply gradient backgrounds and shadows to mobile and desktop drawers for a cleaner look.

## Testing
- `npm run lint` (fails: 19 errors unrelated to this change)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab899eeb688320932b36effc8c4c87